### PR TITLE
Fixed the CSS for the overlapping boxes

### DIFF
--- a/Upgrade_Incremental/nice.css
+++ b/Upgrade_Incremental/nice.css
@@ -76,6 +76,7 @@
 	width: 400px;
 	margin: auto;
 	padding: 5px;
+	margin-top: 20px;
 	
 	border: 3px double black;
 }


### PR DESCRIPTION
added margin-top to #automation-display-up in the css. As part of my HFOSS class I had to fork a repo and do a bugfix. I don't know if you update this game anymore but the boxes shouldn't overlap in firefox anymore.
